### PR TITLE
Return key in Model.primary_key()

### DIFF
--- a/sandman2/model.py
+++ b/sandman2/model.py
@@ -62,13 +62,13 @@ class Model(object):
         return columns
 
     def primary_key(self):
-        """Return the name of the model's primary key field.
+        """Return the key of the model's primary key field.
 
         :rtype: string
         """
         return list(
             self.__table__.primary_key.columns)[  # pylint: disable=no-member
-                0].name
+                0].key
 
     def to_dict(self):
         """Return the resource as a dictionary.


### PR DESCRIPTION
If the column has different name than key, we need key, otherwise it doesn't work.
Consider the following column:

    id_teacher = db.Column('id_lector', db.Integer, primary_key=True, key='id_teacher')

Name gets `id_lector`, key gets `id_teacher`. With name, we get (form `resouce_uri()`):

    AttributeError: 'Teachers' object has no attribute 'id_lector'