### PR TITLE
adding documentation link at the bottom of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ Here's a shot of the new look:
 If `sandman2ctl` doesn't give you fine-grained enough control over your REST
 endpoints, or you'd like to restrict the set of tables made available via
 `sandman2ctl`, you can easily integrate `sandman2` into your application. See
-the documentation for more info.
+the [documentation](http://sandman2.readthedocs.io/en/latest/) for more info.


### PR DESCRIPTION
Although it is replicated, this prevents the reader's scroll to the top of the page to again find the link. 