### PR TITLE
Allow sorting descending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ dist
 .tox
 build
 *.bak
+.idea
+.cache

--- a/sandman2/service.py
+++ b/sandman2/service.py
@@ -5,6 +5,7 @@ ORM models or a database introspection."""
 from flask import request, make_response
 import flask
 from flask.views import MethodView
+from sqlalchemy import asc, desc
 
 # Application imports
 from sandman2.exception import NotFoundException, BadRequestException
@@ -214,7 +215,8 @@ class Service(MethodView):
                 if value.startswith('%'):
                     filters.append(getattr(self.__model__, key).like(str(value), escape='/'))
                 elif key == 'sort':
-                    order.append(getattr(self.__model__, value))
+                    direction = desc if value.startswith('-') else asc
+                    order.append(direction(getattr(self.__model__, value.lstrip('-'))))
                 elif key == 'limit':
                     limit = value
                 elif hasattr(self.__model__, key):

--- a/tests/test_extended_functionality.py
+++ b/tests/test_extended_functionality.py
@@ -42,6 +42,14 @@ def test_sorting(client):
     assert response.json['resources'][0]['ArtistId'] == 43
 
 
+def test_sorting_descending(client):
+    """Can we sort results in descending order?"""
+    response = client.get('/artist/?sort=-Name')
+    assert response.status_code == 200
+    assert len(response.json['resources']) == 276
+    assert response.json['resources'][0]['ArtistId'] == 155
+
+
 def test_limit(client):
     """Do we return sorted results when a 'limit' URL parameter is provided?"""
     response = client.get('/artist/?limit=5')


### PR DESCRIPTION
Still sorts ascending by default. Can sort descending by prepending '-' to the attribute, e.g., `entity?sort=-name`