### PR TITLE
Enable encoding for the read function. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(*parts):
     """Return multiple read calls to different readable objects as a single
     string."""
     # intentionally *not* adding an encoding option to open
-    return codecs.open(os.path.join(HERE, *parts), 'r').read()
+    return codecs.open(os.path.join(HERE, *parts), 'r', encoding='utf-8').read()
 
 LONG_DESCRIPTION = read('README.rst')
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 def read(*parts):
     """Return multiple read calls to different readable objects as a single
     string."""
-    # intentionally *not* adding an encoding option to open
+   
     return codecs.open(os.path.join(HERE, *parts), 'r', encoding='utf-8').read()
 
 LONG_DESCRIPTION = read('README.rst')


### PR DESCRIPTION
The encoding is needed or installation will fail for Python3. I tested this change locally and it works with the encoding. 

Traceback (most recent call last):
  File "setup.py", line 19, in <module>
    LONG_DESCRIPTION = read('README.rst')
  File "setup.py", line 17, in read
    return codecs.open(os.path.join(HERE, *parts), 'r').read()
  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 563: ordinal not in range(128)
