### PR TITLE
replace 'source' with '.' for sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ clean:
 
 install:
 	python -m venv venv && \
-		source venv/bin/activate && \
+		. venv/bin/activate && \
 		pip install -r requirements.txt
 
 docs: install
 	cd docs && make html && cd ..
 
 test: install
-	source venv/bin/activate && \
+	. venv/bin/activate && \
 		py.test --cov=sandman2 tests


### PR DESCRIPTION
To avoid this error:

```
$ make install
python -m venv venv && \
	source venv/bin/activate && \
	pip install -r requirements.txt
/bin/sh: 2: source: not found
Makefile:7: recipe for target 'install' failed
make: *** [install] Error 127
```