### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -17,7 +17,7 @@ classes reflected in the database and add a ``__unicode__`` member function.
 
 Imagine we have a simple blog application consisting of Blog, Post, and User
 models. As expected, each post belongs to a specific user and the model has the
-requisite foreign key to the User table. When we view a Post's assoicated user
+requisite foreign key to the User table. When we view a Post's associated user
 in the admin site, however, we see the following::
 
     <flask_sqlalchemy.user object at 0x10d3cea10>
@@ -59,5 +59,5 @@ classes. Deriving from ``sandman2.AutomapModel`` accomplishes this::
 
 Notice that you can refer to attributes of the class that you know to be present
 (like ``user.name``) without defining the ``name`` column; all other
-columns/properties are reflected. You're meerly *extending* the existing model
+columns/properties are reflected. You're merely *extending* the existing model
 class.

--- a/tests/test_user_models.py
+++ b/tests/test_user_models.py
@@ -65,7 +65,7 @@ def test_validate_post_existing_resource(client):
 
 def test_validate_put_existing(client):
     """Do we get back an error message when making a PUT request for
-    an exisitng resource?"""
+    an existing resource?"""
     response = client.put(
         '/user/1',
         data=json.dumps({


### PR DESCRIPTION
There are small typos in:
- docs/admin.rst
- tests/test_user_models.py

Fixes:
- Should read `merely` rather than `meerly`.
- Should read `existing` rather than `exisitng`.
- Should read `associated` rather than `assoicated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md